### PR TITLE
fix the version number of Solr in the config file to the one installed

### DIFF
--- a/cookbook/recipes/solr.rb
+++ b/cookbook/recipes/solr.rb
@@ -68,7 +68,7 @@ memory_param = solr_memory ? "-m #{solr_memory}" : ""
 
 # TODO: figure out how to make this more dynamic so we aren't hardcoding the
 # sunspot_solr gem dir.  That, or install solr outside of gems
-solr_bin_dir = "#{node[:primero][:home_dir]}/.rvm/gems/ruby-#{node[:primero][:ruby_version]}-#{node[:primero][:ruby_patch]}/gems/sunspot_solr-2.2.7/solr/bin"
+solr_bin_dir = "#{node[:primero][:home_dir]}/.rvm/gems/ruby-#{node[:primero][:ruby_version]}-#{node[:primero][:ruby_patch]}/gems/sunspot_solr-2.3.0/solr/bin"
 supervisor_service 'solr' do
   command "#{solr_bin_dir}/solr start -f -p 8983 -s /srv/primero/application/solr #{memory_param}"
   environment({'RAILS_ENV' => 'production'})


### PR DESCRIPTION
When I tried to run Vagrant provision, it failed because the Solr version installed by the script is different than the one in the config file to start it.
This update the config to the version of Solr installed.