### PR TITLE
Fix markdown formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ The minor version usually means an ongoing development effort and there are thre
 
 To make a change, you should **make a new feature branch** from the tip of the main branch of what you want to work on (mobile, new development or bug fixes). Doing this allows raising multiple pull requests at the same time if necessary. It is also a good way to keep productivity independent from the rate at which the pull requests are looked at
 
-##Example of creating a separate branch for your feature or user story:
+## Example of creating a separate branch for your feature or user story:
 
 * Move to the correct branch. For example `git checkout maint_1.3`
 * Create a new branch with an appropriate name (**also add a story number if there is one and a short description**) and switch to the branch
@@ -39,11 +39,11 @@ To make a change, you should **make a new feature branch** from the tip of the m
 * After that you can checkout to master or create a new branch for the next feature or bug
 * Also take a look at the excellent [OpenMRS guide to using git](https://wiki.openmrs.org/display/docs/Using+Git)
 
-#Tests
+# Tests
 
 **Make sure all Rspec tests pass before making a pull request!!!** Currently the Cucumber feature tests are not used or maintained, but may be resurrected in the future to act as a smoke-test suite.
 
 
-#Note about the Release Target
+# Note about the Release Target
 
 There is also a version file in the code itself in `config/version.rb` which is incremented that after a release. So for example if we just released v1.4.0.5, we increment it to v1.4.0.6

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -25,7 +25,7 @@ following volumes:
  - `/etc/ssl/primero`: You need to place the CouchDB SSL cert/key in this volume with the name `couch.{crt,key}`
  - `/etc/couchdb/local.d`: You can put additional Couch configuration in this volume
 
-####Envvars
+#### Envvars
 
 
  - `COUCHDB_PASSWORD`: the admin password for the default `primero` user.  (default: None)
@@ -37,7 +37,7 @@ This image includes everything except for CouchDB, namely Solr, the Couch change
 watcher, Nginx and Puma.  It also runs all of these processes using
 Supervisor.
 
-####Envvars
+#### Envvars
 
  - `COUCHDB_PASSWORD`: the password for the couch admin user (default: None)
  - `PRIMERO_VIRTUAL_HOST`: virtual host name for the app (e.g. `primero-qa.quoininc.com`) (default: None)

--- a/doc/ssl.md
+++ b/doc/ssl.md
@@ -8,19 +8,19 @@ Primero requires SSL to run. The following options for enabling SSL are availabl
  - **Let's Encrypt:** This is a free, automated [certificate authority](https://letsencrypt.org) that is based on DNS validation. Primero Chef deployment includes support for automatically enabling and periodically renewing Let's Encrypt certificates. See the file `cookbook/README.md` for how to do this.
 
 
-###Application SSL
+### Application SSL
 To get the application SSL cert, you must go through a recognized Certificate
 Authority (CA) or a CA which is trusted by the browsers of the primary users
 of this Primero deployment.  It is currently not possible to run Primero
 except through HTTPS, nor is it advisable to run any part of Primero except
 under HTTPS.
 
-###CouchDB SSL
+### CouchDB SSL
 The CouchDB SSL cert uses a private CA whose root certificate is distributed
 automatically to all of the servers to verify communication. To generate a
 new key and cert, follow the next steps.
 
-####Initial Setup
+#### Initial Setup
 (All from [this site](https://jamielinux.com/articles/2013/08/act-as-your-own-certificate-authority/).)
 
 To setup a new root Certificate Authority to sign CouchDB certs, you need to configure your machine as your own certificate authority (CA).
@@ -91,7 +91,7 @@ See example below.
 See the openssl docs for more info on how to configure things.
 [https://www.openssl.org/docs/](https://www.openssl.org/docs/)
 
-######Example config.cnf
+###### Example config.cnf
 
 ```sh
 [req]
@@ -134,7 +134,7 @@ localityName_default        = Boston
 emailAddress_default        = unknown@quoininc.com
 ```
 
-####Creating and Signing New Certs
+#### Creating and Signing New Certs
 Firstly, copy the openssl configuration file
 
 ```sh


### PR DESCRIPTION
Github doesn't render markdown headers like `#header`. This pull request fixes the rendering by changing all headers to `# header`.