### PR TITLE
added labels to login form-elements

### DIFF
--- a/app/javascript/components/pages/login/login-form/container.jsx
+++ b/app/javascript/components/pages/login/login-form/container.jsx
@@ -70,11 +70,13 @@ const Container = () => {
         render={() => (
           <Form className={css.loginForm} autoComplete="off" noValidate>
             <Field
+              id="user_name"
               name="user_name"
               label={i18n.t("login.username")}
               {...inputProps}
             />
             <Field
+              id="password"
               name="password"
               label={i18n.t("login.password.label")}
               type="password"


### PR DESCRIPTION
This pull request is to add labels in the login form elements. 

Earlier when we tested it with axe and lighthouse tool, wasn't able to recognize the labels that were pointing to each input field

![Screenshot from 2020-06-04 23-38-57](https://user-images.githubusercontent.com/39872794/83797560-7c720400-a6c0-11ea-9cf8-a7a0d2e31e58.png)


After adding id it solves it
![Screenshot from 2020-06-04 23-40-41 (1)](https://user-images.githubusercontent.com/39872794/83797621-94498800-a6c0-11ea-8533-1d7440bf100a.png)
