### PR TITLE
Document cmd to bootstrap primero when using custom configuration

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -181,5 +181,6 @@ It's assumed that a Primero configuration directory will have a script named `lo
 
 ```
 cd docker
+./compose.prod.sh run application primero-bootstrap
 ./compose.configure.sh /path/to/primero/config/directory
 ```


### PR DESCRIPTION
Add to the docker/README.md the instruction to run the command to bootstrap the primero application when using a custom configuration dir. Without that cmd it fails because the database is not setup.