### PR TITLE
Added labels to interactive components

### DIFF
--- a/app/javascript/components/dashboard/dashboard-table/component.jsx
+++ b/app/javascript/components/dashboard/dashboard-table/component.jsx
@@ -23,6 +23,7 @@ const DashboardTable = ({ columns, data, query, title }) => {
     print: false,
     viewColumns: false,
     serverSide: true,
+    setTableProps: () => ({ "aria-label": title }),
     customToolbar: () => null,
     customToolbarSelect: () => null,
     onTableChange: () => null,

--- a/app/javascript/components/dashboard/dashboard-table/component.unit.test.js
+++ b/app/javascript/components/dashboard/dashboard-table/component.unit.test.js
@@ -37,4 +37,12 @@ describe("<DashboardTable />", () => {
 
     expect(testTitle).to.equals("testTitle");
   });
+
+  it("should have attribute aria-label", () => {
+    const label = component.find(MUIDataTable).find("table").first().props()[
+      "aria-label"
+    ];
+
+    expect(label).to.equals(props.title);
+  });
 });

--- a/app/javascript/components/index-table/component.jsx
+++ b/app/javascript/components/index-table/component.jsx
@@ -271,6 +271,7 @@ const Component = ({
     print: false,
     viewColumns: false,
     serverSide: true,
+    setTableProps: () => ({ "aria-label": title }),
     customToolbar: showCustomToolbar && customToolbarSelect,
     selectableRows: "multiple",
     rowsSelected: selectedRecordsOnCurrentPage?.length

--- a/app/javascript/components/index-table/component.unit.test.js
+++ b/app/javascript/components/index-table/component.unit.test.js
@@ -147,6 +147,14 @@ describe("<IndexTable />", () => {
     expect(testTitle).to.equals("testTitle");
   });
 
+  it("should have attribute aria-label", () => {
+    const label = component.find(MUIDataTable).find("table").first().props()[
+      "aria-label"
+    ];
+
+    expect(label).to.equals(props.title);
+  });
+
   it("should change sort order to ascending if user clicks on a column", () => {
     const nameColumnIndex = 3;
     const table = component.find(IndexTable);


### PR DESCRIPTION
 Interactive UI components with certain implicit or explicit WAI-ARIA roles require an accessible name. This pull request is to add aria-labels.