### PR TITLE
Fix fetching subforms from form_section_responses

### DIFF
--- a/app/models/form_section_response.rb
+++ b/app/models/form_section_response.rb
@@ -31,7 +31,7 @@ class FormSectionResponse < ValueObject
 
   def subform(name)
     FormSectionResponseList.new(
-      responses: field(name).flatten,
+      responses: (field(name) || []).flatten,
       form_section: form_section&.fields&.find_by(name: name)&.subform
     )
   end

--- a/app/models/form_section_response.rb
+++ b/app/models/form_section_response.rb
@@ -31,7 +31,7 @@ class FormSectionResponse < ValueObject
 
   def subform(name)
     FormSectionResponseList.new(
-      responses: (field(name) || []).flatten,
+      responses: Array(field(name)).flatten,
       form_section: form_section&.fields&.find_by(name: name)&.subform
     )
   end

--- a/app/models/form_section_response_list.rb
+++ b/app/models/form_section_response_list.rb
@@ -22,7 +22,7 @@ class FormSectionResponseList < ValueObject
 
   def subform(name)
     FormSectionResponseList.new(
-      responses: field(name).flatten,
+      responses: field(name).compact.flatten,
       form_section: subform_section(name)
     )
   end

--- a/spec/services/gbv_kpi_calculation_service_spec.rb
+++ b/spec/services/gbv_kpi_calculation_service_spec.rb
@@ -35,6 +35,17 @@ describe GbvKpiCalculationService do
     end
   end
 
+  describe 'fetching subforms that don\'t exist from form_section_responses' do
+    it 'should return an empty form_section_response_list' do
+      responses = GbvKpiCalculationService
+                  .new(Child.new(data: { action_plan: [] }))
+                  .form_responses(:action_plan)
+                  .subform(:test)
+
+      expect(responses.count).to eql(0)
+    end
+  end
+
   after :each do
     clean_data(FormSection)
   end


### PR DESCRIPTION
This fixes an issue where cases that have data for forms which doesn't contain new subforms, and therefor lack the keys for those subforms, throw errors at runtime.

I'm fixing this here by aligning the `FormSectionResponse#subform` with the rest of the form_section_response api.