### PR TITLE
Pull SolrUtils from the global scope

### DIFF
--- a/app/models/kpi/bucketed_search.rb
+++ b/app/models/kpi/bucketed_search.rb
@@ -16,11 +16,11 @@ class Kpi::BucketedSearch < Kpi::Search
   end
 
   def restricted_field
-    SolrUtils.sunspot_setup(search_model).field(self.class.restricted_field)
+    ::SolrUtils.sunspot_setup(search_model).field(self.class.restricted_field)
   end
 
   def compared_field
-    SolrUtils.sunspot_setup(search_model).field(self.class.compared_field)
+    ::SolrUtils.sunspot_setup(search_model).field(self.class.compared_field)
   end
 
   def days(number)

--- a/app/models/kpi/pivoted_range_search.rb
+++ b/app/models/kpi/pivoted_range_search.rb
@@ -17,11 +17,11 @@ class Kpi::PivotedRangeSearch < Kpi::Search
   end
 
   def range_field
-    SolrUtils.sunspot_setup(search_model).field(self.class.range_field)
+    ::SolrUtils.sunspot_setup(search_model).field(self.class.range_field)
   end
 
   def pivot_field
-    SolrUtils.sunspot_setup(search_model).field(self.class.pivot_field)
+    ::SolrUtils.sunspot_setup(search_model).field(self.class.pivot_field)
   end
 
   # Shortening this method (or the others below) would either:


### PR DESCRIPTION
This is to avoid potential missing constant issues that might arise from
a mixture of Sunspot + Ruby Scopes + Rails constant loading shenanigans.