### PR TITLE
Perf kpi calculations form sections

### DIFF
--- a/app/models/form_section_response.rb
+++ b/app/models/form_section_response.rb
@@ -30,9 +30,14 @@ class FormSectionResponse < ValueObject
   end
 
   def subform(name)
+    return nil unless form_section
+
     FormSectionResponseList.new(
       responses: Array(field(name)).flatten,
-      form_section: form_section&.fields&.find_by(name: name)&.subform
+      # This is used elsewhere to make use of eager loads but this long
+      # chain of null propagation makes me cringe and indicates there is some
+      # shared responcibility for managing this that shouldn't be here.
+      form_section: form_section.fields.select { |f| f.name.to_sym == name }.first&.subform
     )
   end
 end

--- a/app/models/form_section_response_list.rb
+++ b/app/models/form_section_response_list.rb
@@ -32,11 +32,7 @@ class FormSectionResponseList < ValueObject
   def subform_section(name)
     return nil unless form_section
 
-    FormSection
-      .joins(subform_field: :form_section)
-      .find_by(
-        form_sections_fields: { id: form_section.id },
-        fields: { name: name }
-      )
+    # Take adavantage of eager loaded fields and subforms
+    form_section.fields.select { |f| f.name.to_sym == name }.first&.subform
   end
 end

--- a/app/services/gbv_kpi_calculation_service.rb
+++ b/app/services/gbv_kpi_calculation_service.rb
@@ -115,7 +115,13 @@ class GbvKpiCalculationService
   end
 
   def form_responses(form_section_unique_id)
-    form_section = FormSection.find_by(unique_id: form_section_unique_id)
+    # This only preloads subforms at depth 1 (which is most subforms).
+    # Any subforms which are deeper will cause new queries for the subform
+    # and for it's fields.
+    form_section = FormSection
+      .eager_load(fields: { subform: :fields })
+      .find_by(unique_id: form_section_unique_id)
+
     form_section_results = access_migrated_forms(form_section_unique_id)
 
     return FormSectionResponseList.new(responses: [], form_section: nil) unless form_section

--- a/spec/support/matchers/queries.rb
+++ b/spec/support/matchers/queries.rb
@@ -1,0 +1,49 @@
+RSpec::Matchers.define :make_queries do |expected|
+
+  match do |block|
+    count_queries(&block) == expected
+  end
+
+  def count_queries(&block)
+    @analyser = QueryAnalyser.new
+    ActiveSupport::Notifications
+      .subscribed(@analyser.to_proc, 'sql.active_record', &block)
+    @analyser.query_count
+  end
+
+  failure_message_for_should do |actual|
+    <<~MESSAGE
+      Expected to run exactly #{expected} queries but ran #{@analyser.query_count}.
+      
+      Queries Ran:
+        #{@analyser.queries.map { |q| "#{q[:name]}: #{q[:sql]}" }.join("\n\n  ")}
+
+    MESSAGE
+  end
+
+  class QueryAnalyser
+    def initialize
+      @queries = []
+    end
+
+    def call(name, start, finish, message_id, values)
+      @queries << values
+    end
+
+    def to_proc
+      method(:call)
+    end
+
+    def query_count
+      @queries.count { |q| ['CACHE', 'SCHEMA'].exclude?(q[:name]) }
+    end
+
+    def queries
+      @queries
+    end
+  end
+
+  def supports_block_expectations?
+    true
+  end
+end


### PR DESCRIPTION
This decreases the number of queries needed for calculating kpis through eager loading and caching.

Todo:
- [x] Architecture feedback
- [ ] Rubocop