### PR TITLE
Kpi performance reduce location queries

### DIFF
--- a/app/models/kpi/pivoted_range_search.rb
+++ b/app/models/kpi/pivoted_range_search.rb
@@ -72,6 +72,8 @@ class Kpi::PivotedRangeSearch < Kpi::Search
       .to_a
       .transpose
 
+    return @data = [] if location_codes.nil? || rows.nil?
+
     # Should use pluck but `placename` is a `localized_property` which uses
     # some ruby to get the right value, so we can't delegate to the db only.
     placenames = Location.where(location_code: location_codes)

--- a/app/services/gbv_kpi_calculation_service.rb
+++ b/app/services/gbv_kpi_calculation_service.rb
@@ -130,9 +130,9 @@ class GbvKpiCalculationService
     # Any subforms which are deeper will cause new queries for the subform
     # and for it's fields.
     @form_section_cache ||= Hash.new do |cache, form_section_unique_id|
-      cache[form_section_unique_id] = FormSection
-        .eager_load(fields: { subform: :fields })
-        .find_by(unique_id: form_section_unique_id)
+      cache[form_section_unique_id] =
+        FormSection.eager_load(fields: { subform: :fields })
+                   .find_by(unique_id: form_section_unique_id)
     end
   end
 

--- a/spec/models/kpi/number_of_cases_spec.rb
+++ b/spec/models/kpi/number_of_cases_spec.rb
@@ -27,6 +27,15 @@ describe Kpi::NumberOfCases, search: true do
       admin_level: 2
     )
 
+    @manchester = Location.create!(
+      location_code: '40',
+      name: 'Manchester',
+      placename: 'Manchester',
+      type: 'County',
+      hierarchy_path: 'GBR.01.40',
+      admin_level: 2
+    )
+
     Child.create!(data: {
                     module_id: PrimeroModule::GBV,
                     owned_by_location: @london.location_code,
@@ -41,7 +50,22 @@ describe Kpi::NumberOfCases, search: true do
                     created_at: DateTime.parse('2020/10/01')
                   })
 
+    Child.create!(data: {
+                    module_id: PrimeroModule::GBV,
+                    owned_by_location: @manchester.location_code,
+                    owned_by_groups: [group3],
+                    created_at: DateTime.parse('2020/11/01')
+                  })
+
     Sunspot.commit
+  end
+
+  describe 'Performance' do
+    it 'should only use two queries' do
+      kpi = Kpi::NumberOfCases.new(from, to, [group1, group3])
+
+      expect { kpi.to_json }.to make_queries(1)
+    end
   end
 
   with 'No cases' do


### PR DESCRIPTION
I've reduced the number of potential queries made to pull location data from the db in the KPIs from N (where N is the number of locations covered) to 1. This introduces some more loops over the data to accomplish that but under the assumption that N sql queries are slower than 4N Ruby loops, we're still making improvements.

We could move to a more imperative approach and do it with 2 loops but we loose all the Ruby niceness ha.

I should note, I would have used `pluck` to pull only the placename data out of the db but, placename is localized and so requires the `Location` object to pull the appropriate value out. If there is a reasonable way to do this let me know!