### PR TITLE
Kpi UI custom date ranges

### DIFF
--- a/app/javascript/components/key-performance-indicators/components/date-range-select/component.jsx
+++ b/app/javascript/components/key-performance-indicators/components/date-range-select/component.jsx
@@ -19,6 +19,8 @@ const Component = ({ ranges, selectedRange, withCustomRange, setSelectedRange, d
     )
   );
 
+  const [showCustomLabel, setShowCustomLabel] = useState(false);
+
   const handleSelectChange = event => {
     if (event.target.value === CUSTOM_RANGE) return;
 
@@ -39,11 +41,22 @@ const Component = ({ ranges, selectedRange, withCustomRange, setSelectedRange, d
     setCustomRange(newRange);
   };
   const handleCustomRangeClick = () => setShowRangePicker(true);
-  const handleDateRangeDialogClose = () => setShowRangePicker(false);
+  const handleDateRangeDialogClose = () => {
+    setShowRangePicker(false);
+    setShowCustomLabel(false);
+  };
+  const handleSelectOpen = () => setShowCustomLabel(true);
+  const handleSelectClose = () => {
+    // This is a little hacky. It's just to that the transition from open
+    // with label isn't as jarring to closed without label
+    setTimeout(() => setShowCustomLabel(false), 150);
+  };
+
+  const customRangeDates = `${i18n.toTime("key_performance_indicators.date_format", customRange.from)} - ${i18n.toTime("key_performance_indicators.date_format", customRange.to)}`;
 
   return (
     <FormControl>
-      <Select onChange={handleSelectChange} value={selectedRange.value} disabled={disabled}>
+      <Select onOpen={handleSelectOpen} onClose={handleSelectClose} onChange={handleSelectChange} value={selectedRange.value} disabled={disabled}>
         {ranges.map(range => (
           <MenuItem key={range.value} value={range.value}>
             {range.name}
@@ -51,8 +64,7 @@ const Component = ({ ranges, selectedRange, withCustomRange, setSelectedRange, d
         ))}
         {withCustomRange && (
           <MenuItem key={CUSTOM_RANGE} value={customRange.value} onClick={handleCustomRangeClick}>
-            {i18n.toTime("key_performance_indicators.date_format", customRange.from)} -{" "}
-            {i18n.toTime("key_performance_indicators.date_format", customRange.to)}
+            {showCustomLabel ? customRange.name : customRangeDates}
           </MenuItem>
         )}
       </Select>

--- a/app/javascript/components/key-performance-indicators/components/date-range-select/component.jsx
+++ b/app/javascript/components/key-performance-indicators/components/date-range-select/component.jsx
@@ -52,11 +52,20 @@ const Component = ({ ranges, selectedRange, withCustomRange, setSelectedRange, d
     setTimeout(() => setShowCustomLabel(false), 150);
   };
 
-  const customRangeDates = `${i18n.toTime("key_performance_indicators.date_format", customRange.from)} - ${i18n.toTime("key_performance_indicators.date_format", customRange.to)}`;
+  const customRangeDates = `${i18n.toTime("key_performance_indicators.date_format", customRange.from)} - ${i18n.toTime(
+    "key_performance_indicators.date_format",
+    customRange.to
+  )}`;
 
   return (
     <FormControl>
-      <Select onOpen={handleSelectOpen} onClose={handleSelectClose} onChange={handleSelectChange} value={selectedRange.value} disabled={disabled}>
+      <Select
+        onOpen={handleSelectOpen}
+        onClose={handleSelectClose}
+        onChange={handleSelectChange}
+        value={selectedRange.value}
+        disabled={disabled}
+      >
         {ranges.map(range => (
           <MenuItem key={range.value} value={range.value}>
             {range.name}

--- a/app/javascript/components/key-performance-indicators/components/date-range-select/component.unit.test.js
+++ b/app/javascript/components/key-performance-indicators/components/date-range-select/component.unit.test.js
@@ -4,7 +4,7 @@ import { setupMountedComponent } from "../../../../test";
 import DateRangeSelect from "./component";
 
 describe("<DateRangeSelect />", () => {
-  const i18n = { t: () => "" };
+  const i18n = { t: () => "", toTime: () => "" };
   const commonDateRanges = CommonDateRanges.from(new Date(), { t: () => {} });
 
   const ranges = [commonDateRanges.Last3Months, commonDateRanges.Last6Months, commonDateRanges.LastYear];

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1327,6 +1327,8 @@ en:
     feedback: "Feedback"
     other: "Other"
     date_format: "%b %Y"
+    date_range_select:
+      custom_range: 'Custom'
     long_date_format: "dd/MM/yyyy"
     time_periods:
       all_time: 'All Time'


### PR DESCRIPTION
Based on UAT feedback the custom date range picker for the KPIs has been changed so that, while the user is selecting and option from the set of possible date ranges the custom range is labelled "Custom". When closed, the label of the custom range is "<start date> - <end date>".