### PR TITLE
Fix tz bug in date ranges

### DIFF
--- a/app/javascript/components/key-performance-indicators/utils/common-date-ranges.js
+++ b/app/javascript/components/key-performance-indicators/utils/common-date-ranges.js
@@ -1,4 +1,4 @@
-import { addMinutes, subMinutes, subMonths, startOfMonth, endOfMonth } from "date-fns";
+import { subMonths, startOfMonth, endOfMonth } from "date-fns";
 
 import DateRange from "./date-range";
 import { ALL_TIME, CURRENT_MONTH, MONTHS_3, MONTHS_6, MONTHS_12 } from "./constants";

--- a/app/javascript/components/key-performance-indicators/utils/common-date-ranges.js
+++ b/app/javascript/components/key-performance-indicators/utils/common-date-ranges.js
@@ -7,47 +7,37 @@ import { ALL_TIME, CURRENT_MONTH, MONTHS_3, MONTHS_6, MONTHS_12 } from "./consta
 // This fixes an issue where dates are out by 1 hour because of timezone issues.
 
 const CommonDateRanges = {
-  adjustTimezone(target, source) {
-    const targetTZO = target.getTimezoneOffset();
-    const sourceTZO = source.getTimezoneOffset();
-
-    const dstDiff = targetTZO - sourceTZO;
-
-    const finalDate = dstDiff >= 0 ? addMinutes(source, dstDiff) : subMinutes(source, Math.abs(dstDiff));
-
-    return finalDate;
-  },
   from(today = new Date(), i18n) {
     return {
       AllTime: new DateRange(
         ALL_TIME,
         i18n.t("key_performance_indicators.time_periods.all_time"),
         new Date(Date.parse("01/01/2000")),
-        this.adjustTimezone(today, endOfMonth(today))
+        endOfMonth(today)
       ),
       CurrentMonth: new DateRange(
         CURRENT_MONTH,
         i18n.t("key_performance_indicators.time_periods.current_month"),
-        this.adjustTimezone(today, startOfMonth(today)),
-        this.adjustTimezone(today, endOfMonth(today))
+        startOfMonth(today),
+        endOfMonth(today)
       ),
       Last3Months: new DateRange(
         MONTHS_3,
         i18n.t("key_performance_indicators.time_periods.last_3_months"),
-        this.adjustTimezone(today, startOfMonth(subMonths(today, 2))),
-        this.adjustTimezone(today, endOfMonth(today))
+        startOfMonth(subMonths(today, 2)),
+        endOfMonth(today)
       ),
       Last6Months: new DateRange(
         MONTHS_6,
         i18n.t("key_performance_indicators.time_periods.last_6_months"),
-        this.adjustTimezone(today, startOfMonth(subMonths(today, 5))),
-        this.adjustTimezone(today, endOfMonth(today))
+        startOfMonth(subMonths(today, 5)),
+        endOfMonth(today)
       ),
       LastYear: new DateRange(
         MONTHS_12,
         i18n.t("key_performance_indicators.time_periods.last_1_year"),
-        this.adjustTimezone(today, startOfMonth(subMonths(today, 11))),
-        this.adjustTimezone(today, endOfMonth(today))
+        startOfMonth(subMonths(today, 11)),
+        endOfMonth(today)
       )
     };
   }


### PR DESCRIPTION
I was applying the tz of the current day to dates in the past which can
result in a date range like: April 23:59:59 (GMT+1) to Feb 00:00:00
(GMT) becomming April 23:59:59 (GMT+1) to Jan 23:00:00 (GMT).