### PR TITLE
Fix tz bug!

### DIFF
--- a/app/javascript/components/key-performance-indicators/action-creators.js
+++ b/app/javascript/components/key-performance-indicators/action-creators.js
@@ -7,17 +7,20 @@ export default identifier => {
   const getKPI = actionsForKPI(identifier);
   const path = pathsForKPI(identifier);
 
-  return dateRange => ({
-    type: getKPI,
-    KPIidentifier: identifier,
-    api: {
-      path,
-      params: dateRange
+
+  return dateRange => {
+    return {
+      type: getKPI,
+      KPIidentifier: identifier,
+      api: {
+        path,
+        params: dateRange
         ? {
-            from: toServerDateFormat(dateRange.from),
-            to: toServerDateFormat(dateRange.to)
-          }
+          from: toServerDateFormat(dateRange.from, { normalize: true }),
+          to: toServerDateFormat(dateRange.to, { normalize: true })
+        }
         : {}
+      }
     }
-  });
+  };
 };

--- a/app/javascript/components/key-performance-indicators/action-creators.js
+++ b/app/javascript/components/key-performance-indicators/action-creators.js
@@ -7,7 +7,6 @@ export default identifier => {
   const getKPI = actionsForKPI(identifier);
   const path = pathsForKPI(identifier);
 
-
   return dateRange => {
     return {
       type: getKPI,
@@ -15,12 +14,12 @@ export default identifier => {
       api: {
         path,
         params: dateRange
-        ? {
-          from: toServerDateFormat(dateRange.from, { normalize: true }),
-          to: toServerDateFormat(dateRange.to, { normalize: true })
-        }
-        : {}
+          ? {
+              from: toServerDateFormat(dateRange.from, { normalize: true }),
+              to: toServerDateFormat(dateRange.to, { normalize: true })
+            }
+          : {}
       }
-    }
+    };
   };
 };

--- a/app/javascript/components/key-performance-indicators/utils/common-date-ranges.js
+++ b/app/javascript/components/key-performance-indicators/utils/common-date-ranges.js
@@ -6,38 +6,38 @@ import { ALL_TIME, CURRENT_MONTH, MONTHS_3, MONTHS_6, MONTHS_12 } from "./consta
 const CommonDateRanges = {
   from(today = new Date(), i18n) {
     // Convert local datetime into UTC
-    today = new Date(today.toISOString().split('T')[0])
+    const start = new Date(today.toISOString().split("T")[0]);
 
     return {
       AllTime: new DateRange(
         ALL_TIME,
         i18n.t("key_performance_indicators.time_periods.all_time"),
         new Date(Date.parse("01/01/2000")),
-        endOfMonth(today)
+        endOfMonth(start)
       ),
       CurrentMonth: new DateRange(
         CURRENT_MONTH,
         i18n.t("key_performance_indicators.time_periods.current_month"),
-        startOfMonth(today),
-        endOfMonth(today)
+        startOfMonth(start),
+        endOfMonth(start)
       ),
       Last3Months: new DateRange(
         MONTHS_3,
         i18n.t("key_performance_indicators.time_periods.last_3_months"),
-        startOfMonth(subMonths(today, 2)),
-        endOfMonth(today)
+        startOfMonth(subMonths(start, 2)),
+        endOfMonth(start)
       ),
       Last6Months: new DateRange(
         MONTHS_6,
         i18n.t("key_performance_indicators.time_periods.last_6_months"),
-        startOfMonth(subMonths(today, 5)),
-        endOfMonth(today)
+        startOfMonth(subMonths(start, 5)),
+        endOfMonth(start)
       ),
       LastYear: new DateRange(
         MONTHS_12,
         i18n.t("key_performance_indicators.time_periods.last_1_year"),
-        startOfMonth(subMonths(today, 11)),
-        endOfMonth(today)
+        startOfMonth(subMonths(start, 11)),
+        endOfMonth(start)
       )
     };
   }

--- a/app/javascript/components/key-performance-indicators/utils/common-date-ranges.js
+++ b/app/javascript/components/key-performance-indicators/utils/common-date-ranges.js
@@ -5,6 +5,9 @@ import { ALL_TIME, CURRENT_MONTH, MONTHS_3, MONTHS_6, MONTHS_12 } from "./consta
 
 const CommonDateRanges = {
   from(today = new Date(), i18n) {
+    // Convert local datetime into UTC
+    today = new Date(today.toISOString().split('T')[0])
+
     return {
       AllTime: new DateRange(
         ALL_TIME,


### PR DESCRIPTION
I'm forcing the date passed into the `CommonDateRanges.from` to be parsed as UTC which lines up all of the date processing we do under the hood nicely, leading to the correct date produced by `format` from the `date-fns` library!