### PR TITLE
Move to using UTC date for testing.

### DIFF
--- a/app/javascript/libs/component-helpers.unit.test.js
+++ b/app/javascript/libs/component-helpers.unit.test.js
@@ -165,7 +165,7 @@ describe("component-helpers", () => {
 
   describe("endOfDay", () => {
     it("should return the end of day for an input date", () => {
-      expect(endOfDay(parseISO("2010-05-01")).toISOString()).to.equal("2010-05-01T23:59:59.000Z");
+      expect(endOfDay(new Date("2010-05-01")).toISOString()).to.equal("2010-05-01T23:59:59.000Z");
     });
   });
 });


### PR DESCRIPTION
`date-fns:parseISO` parses the given string in the local timezone.
Converting a `Date` to string via `toISOString` converts a local
datetime into UTC datetime. Since `endOfDay` takes that UTC datetime,
manipulates it as a string and passes it off to `date-fns:parseISO`
again, it's going to be impacted by timezone conversion twice.

This is fine if the local timezone is UTC-n because T00:00:00 + 0n:00:00
(used to convert the local time to UTC time) is still the same date.

If the local timezone is UTC+n then it becomes T00:00:00 - 0n:00:00
which will push the date back into the previous day! So the string
output from `toISOString` in a UTC+n timezone will be of the previous day
(and month, year if the day is on a boundary).

Strings passed to `new Date` are assumed to be in UTC so when we use
that in the test, it works in UTC+n and UTC-n timezones!

Dates are hard.