### PR TITLE
Add minio as storage type

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   config.force_ssl = true
   config.ssl_options = { redirect: false }
 
-  storage_type = %w[local microsoft amazon].find do |t|
+  storage_type = %w[local microsoft amazon minio].find do |t|
     t == ENV['PRIMERO_STORAGE_TYPE']
   end || 'local'
   config.active_storage.service = storage_type.to_sym

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -18,3 +18,12 @@ amazon:
   secret_access_key:  <%= ENV['PRIMERO_STORAGE_AWS_SECRET_ACCESS_KEY'] %>
   region: <%= ENV['PRIMERO_STORAGE_AWS_REGION'] %>
   bucket: <%= ENV['PRIMERO_STORAGE_AWS_BUCKET'] %>
+
+minio:
+  service: S3
+  access_key_id: <%= ENV['PRIMERO_STORAGE_MINIO_ACCESS_KEY'] %>
+  secret_access_key:  <%= ENV['PRIMERO_STORAGE_MINIO_SECRET_ACCESS_KEY'] %>
+  region: <%= ENV['PRIMERO_STORAGE_MINIO_REGION'] %>
+  bucket: <%= ENV['PRIMERO_STORAGE_MINIO_BUCKET'] %>
+  endpoint: <%= ENV['PRIMERO_STORAGE_MINIO_ENDPOINT'] %>
+  force_path_style: true


### PR DESCRIPTION
This pull request adds min.io as storage type for primero instances where storage should be self-hosted.

An example of `docker-compose.yml` file to start the min.io server can be:

```
version: "3.3"

services:
  minio:
    container_name: minio
    image: quay.io/minio/minio
    command: server /data --console-address ":9001"
    volumes:
      - ./minio-data:/data
    restart: unless-stopped
    ports:
      - 9000:9000
      - 9001:9001
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 30s
      timeout: 20s
      retries: 3
```

Also this are some env variables to be added in `inventory.yml` file:

```
---
all:
  hosts:
    primero.example.com:
      [...]
      environment_variables:
        PRIMERO_STORAGE_TYPE: minio
        PRIMERO_STORAGE_MINIO_ACCESS_KEY: primero-test
        PRIMERO_STORAGE_MINIO_SECRET_ACCESS_KEY: accesskey
        PRIMERO_STORAGE_MINIO_REGION: us-east-1
        PRIMERO_STORAGE_MINIO_BUCKET: primero-test
        PRIMERO_STORAGE_MINIO_ENDPOINT: https://s3.primero.example.com
```