### PR TITLE
Rapidpro Connector

### DIFF
--- a/app/services/api_connector/abstract_connector.rb
+++ b/app/services/api_connector/abstract_connector.rb
@@ -24,7 +24,7 @@ class ApiConnector::AbstractConnector
     self.class.id
   end
 
-  def default_env_prefix
+  def self.default_env_prefix
     "PRIMERO_CONNECT_API_#{id.upcase}_"
   end
 

--- a/app/services/api_connector/rapidpro_connector.rb
+++ b/app/services/api_connector/rapidpro_connector.rb
@@ -1,0 +1,31 @@
+class ApiConnector::RapidproConnector < ApiConnector::AbstractConnector
+  IDENTIFIER = 'rp'
+
+  def self.id
+    IDENTIFIER
+  end
+
+  def self.build_from_env(options = {})
+    prefix = options[:prefix] || default_env_prefix
+    config = ENV.select { |key, _| key.start_with?(prefix) }
+                .transform_keys { |key| key.delete_prefix(prefix).downcase }
+                .with_indifferent_access
+
+    token = config.delete(:token)
+    config['default_headers'] = {
+      Authorization: "Token #{token}"
+    }
+    new(config)
+  end
+
+  def send_message(urn, text)
+    connection.post('/api/v2/broadcasts.json', post_params(urn, text))
+  end
+
+  def post_params(urn, text)
+    {
+      urns: [urn],
+      text:
+    }
+  end
+end

--- a/spec/services/api_connector/rapidpro_connector_spec.rb
+++ b/spec/services/api_connector/rapidpro_connector_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe ApiConnector::RapidproConnector do
+  let(:connection) { double('connection') }
+  let(:connector) do
+    c = ApiConnector::RapidproConnector.new
+    (c.connection = connection) && c
+  end
+
+  describe '.send_message' do
+    it 'calls the rapidpro broadcasts endpoint with the desired output' do
+      expect(connection).to(
+        receive(:post).with('/api/v2/broadcasts.json', { text: 'test message', urns: ['tel:+11234561234'] })
+      )
+      connector.send_message('tel:+11234561234', 'test message')
+    end
+  end
+end


### PR DESCRIPTION
This is a very early WIP of the ongoing work for handling primero -> rapidpro connections. I don't expect this to get merged, but it has been indicated that it will be useful for tracking.

The broader objectives are:
- [ ] Create the necessary plumbing to send messages from primero to rapidpro following the pattern of the other `api_connectors`.
- [ ] Create a new record type for rapidpro messages in the same general spirit as `AuditLogs`.
- [ ] Create a UI for sending messages to various users/groups in the settings page, and viewing previously sent messages.