### PR TITLE
Bugfix in avg-decimals

### DIFF
--- a/app/javascript/libs/expressions/operators/avg.js
+++ b/app/javascript/libs/expressions/operators/avg.js
@@ -23,7 +23,7 @@ export default (expressions, extra) => ({
 
     const res = sum / (count === 0 ? 1 : count);
 
-    if (decimalPlaces) {
+    if (decimalPlaces || decimalPlaces === 0) {
       return parseFloat(res.toFixed(decimalPlaces));
     }
 

--- a/app/javascript/libs/expressions/operators/avg.unit.test.js
+++ b/app/javascript/libs/expressions/operators/avg.unit.test.js
@@ -7,6 +7,7 @@ import avgOperator from "./avg";
 describe("avgOperator", () => {
   const operator = avgOperator(["a", "b", "c"]);
   const decimalPlaceOperator = avgOperator(["a", "b", "c"], { decimalPlaces: 3 });
+  const roundOperator = avgOperator(["a", "b", "c"], {decimalPlaces: 0});
 
   it("should return avg", () => {
     expect(operator.evaluate({ a: 3, b: 4, c: 2 })).to.deep.equals(3);
@@ -26,4 +27,7 @@ describe("avgOperator", () => {
   it("returns a float when decimal places are specified", () => {
     expect(decimalPlaceOperator.evaluate({ a: 1, b: 4 })).to.deep.equals(2.5);
   });
+  it("rounds correctly if decimalPlaces are 0", () => {
+    expect(roundOperator.evaluate({a: 1, b: 1, c:3})).to.deep.equals(2);
+  })
 });


### PR DESCRIPTION
I had intended that specifying decimalPlaces: 0 would have been a way of explicitly choosing between the new rounding behaviour and the old floor behaviour. Unfortunately I was checking if decimalPlaces was truthy, and zero is not truthy...