### PR TITLE
Record form calculated fields

### DIFF
--- a/app/javascript/components/record-form/form/record-form.jsx
+++ b/app/javascript/components/record-form/form/record-form.jsx
@@ -67,7 +67,7 @@ function RecordForm({
 
   const bindRecalculateFields = recalculateFields => {
     bindedRecalculateFields.current = recalculateFields;
-  }
+  };
 
   const buildValidationSchema = formSections => {
     const schema = formSections.reduce((obj, item) => {
@@ -186,7 +186,7 @@ function RecordForm({
     if (typeof bindedRecalculateFields.current === "function") {
       bindedRecalculateFields.current();
     }
-  })
+  });
 
   const handleConfirm = onConfirm => {
     onConfirm();
@@ -201,7 +201,6 @@ function RecordForm({
   const setFormikValues = values => {
     formikValues.current = values;
   };
-
 
   if (!isEmpty(initialValues) && !isEmpty(forms)) {
     const validationSchema = buildValidationSchema(forms);
@@ -231,6 +230,7 @@ function RecordForm({
               if (values) {
                 calculatedFields.forEach(field => {
                   const result = parseExpression(field.calculation.expression).evaluate(values);
+
                   if (values[field.name] !== result) {
                     setFieldValue(field.name, result, false);
                   }


### PR DESCRIPTION
This implements calculated fields at the record level, as opposed to just at the subform level.

I've put the logic in the record-form component because it's necessary to recalculate whenever any of the relevant fields on the record change, even if the calculated field component is not currently rendered (perhaps as it's on a different form section).