### PR TITLE
DAO: filter by "assigned to me"

### DIFF
--- a/app/javascript/components/index-filters/components/filter-types/value-handlers.js
+++ b/app/javascript/components/index-filters/components/filter-types/value-handlers.js
@@ -42,6 +42,11 @@ const customCheckBoxFilters = {
         id: `assigned_user_names=${user}`,
         key: "assigned_user_names",
         display_name: label("referred_cases", "cases.filter_by.referred_cases")
+      },
+      {
+        id: `assign=${user}`,
+        key: "assign",
+        display_name: label("assigned_cases", "cases.filter_by.assigned_to_me")
       }
     ],
     isObject: true,

--- a/app/javascript/components/index-filters/components/filter-types/value-handlers.unit.test.js
+++ b/app/javascript/components/index-filters/components/filter-types/value-handlers.unit.test.js
@@ -110,7 +110,7 @@ describe("<IndexFilters />/filter-types/value-handlers", () => {
           {
             id: "owned_by=josh",
             key: "owned_by",
-            display_name: "cases.filter_by.referred_cases"
+            display_name: "cases.filter_by.my_cases"
           },
           {
             id: "assigned_user_names=josh",
@@ -127,7 +127,8 @@ describe("<IndexFilters />/filter-types/value-handlers", () => {
         fieldName: "or"
       };
 
-      const label = jest.fn().mockReturnValue("cases.filter_by.referred_cases");
+      // This mock just regurgitates the i18n key.
+      const label = jest.fn((_labelName, i18nString) => i18nString);
 
       const output = getFilterProps({ filter, user, i18n, label });
 

--- a/app/javascript/components/index-filters/components/filter-types/value-handlers.unit.test.js
+++ b/app/javascript/components/index-filters/components/filter-types/value-handlers.unit.test.js
@@ -116,6 +116,11 @@ describe("<IndexFilters />/filter-types/value-handlers", () => {
             id: "assigned_user_names=josh",
             key: "assigned_user_names",
             display_name: "cases.filter_by.referred_cases"
+          },
+          {
+            id: "assign=josh",
+            key: "assign",
+            display_name: "cases.filter_by.assigned_to_me"
           }
         ],
         isObject: true,

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -756,7 +756,8 @@ class Filter < ValueObject
     self.options = I18n.available_locales.map do |locale|
       locale_options = [registration_date_options(locale), assessment_requested_on_options(locale),
                         date_case_plan_options(locale), date_closure_options(locale), followup_date_options(locale),
-                        date_reunification_options(locale), tracing_date_options(locale), service_date_options(locale), reassigned_transferred_on_date_options(locale)]
+                        date_reunification_options(locale), tracing_date_options(locale), service_date_options(locale),
+                        reassigned_transferred_on_date_options(locale)]
       date_label = opts[:user].gbv? ? 'created_at' : 'date_of_creation'
       locale_options << created_at_options(locale, date_label)
       { locale => locale_options }

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -752,6 +752,7 @@ class Filter < ValueObject
     end.inject(&:merge)
   end
 
+  # rubocop:disable Metrics/AbcSize
   def cases_by_date_options(opts = {})
     self.options = I18n.available_locales.map do |locale|
       locale_options = [registration_date_options(locale), assessment_requested_on_options(locale),
@@ -763,6 +764,7 @@ class Filter < ValueObject
       { locale => locale_options }
     end.inject(&:merge)
   end
+  # rubocop:enable Metrics/AbcSize
 
   def registration_date_options(locale)
     {

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -756,7 +756,7 @@ class Filter < ValueObject
     self.options = I18n.available_locales.map do |locale|
       locale_options = [registration_date_options(locale), assessment_requested_on_options(locale),
                         date_case_plan_options(locale), date_closure_options(locale), followup_date_options(locale),
-                        date_reunification_options(locale), tracing_date_options(locale), service_date_options(locale)]
+                        date_reunification_options(locale), tracing_date_options(locale), service_date_options(locale), reassigned_transferred_on_date_options(locale)]
       date_label = opts[:user].gbv? ? 'created_at' : 'date_of_creation'
       locale_options << created_at_options(locale, date_label)
       { locale => locale_options }
@@ -823,6 +823,13 @@ class Filter < ValueObject
     {
       id: 'service_implemented_day_times',
       display_name: I18n.t('children.selectable_date_options.service_implemented_day_time', locale:)
+    }
+  end
+
+  def reassigned_transferred_on_date_options(locale)
+    {
+      id: 'reassigned_transferred_on',
+      display_name: I18n.t('children.selectable_date_options.reassigned_transferred_on', locale:)
     }
   end
 

--- a/app/models/search_filters/transition_value.rb
+++ b/app/models/search_filters/transition_value.rb
@@ -1,8 +1,12 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2014 - 2025 UNICEF. All rights reserved.
+
+# This filter selects by the transitioned_to field on related transitions.
 class SearchFilters::TransitionValue < SearchFilters::Value
-  def query(record_class)
+  def query(record_class) # rubocop:disable Metrics/MethodLength this is pretty much just a long SQL template
     ActiveRecord::Base.sanitize_sql_for_conditions(
       [
-        # %(EXISTS (SELECT 1 = 1)),
         %(
         EXISTS (
           SELECT 1

--- a/app/models/search_filters/transition_value.rb
+++ b/app/models/search_filters/transition_value.rb
@@ -4,7 +4,8 @@
 
 # This filter selects by the transitioned_to field on related transitions.
 class SearchFilters::TransitionValue < SearchFilters::Value
-  def query(record_class) # rubocop:disable Metrics/MethodLength this is pretty much just a long SQL template
+  # rubocop:disable Metrics/MethodLength this is pretty much just a long SQL template
+  def query(record_class)
     ActiveRecord::Base.sanitize_sql_for_conditions(
       [
         %(
@@ -12,14 +13,13 @@ class SearchFilters::TransitionValue < SearchFilters::Value
           SELECT 1
           FROM transitions as transitions
           WHERE transitions.type = :transition_type
-          AND #{record_class.table_name}.id::varchar = transitions.record_id
+          AND #{record_class.table_name}.id = transitions.record_id::uuid
           AND transitions.transitioned_to = :value
         )
         ),
-        { transition_type: field_name, record_class:, value: }
+        { transition_type: field_name, value: }
       ]
     )
   end
+  # rubocop:enable Metrics/MethodLength
 end
-
-# AND id = transitions.record_id

--- a/app/models/search_filters/transition_value.rb
+++ b/app/models/search_filters/transition_value.rb
@@ -13,11 +13,12 @@ class SearchFilters::TransitionValue < SearchFilters::Value
           SELECT 1
           FROM transitions as transitions
           WHERE transitions.type = :transition_type
+          AND transitions.record_type = :record_type
           AND #{record_class.table_name}.id = transitions.record_id::uuid
           AND transitions.transitioned_to = :value
         )
         ),
-        { transition_type: field_name, value: }
+        { transition_type: field_name, record_type: record_class.name, value: }
       ]
     )
   end

--- a/app/models/search_filters/transition_value.rb
+++ b/app/models/search_filters/transition_value.rb
@@ -1,0 +1,21 @@
+class SearchFilters::TransitionValue < SearchFilters::Value
+  def query(record_class)
+    ActiveRecord::Base.sanitize_sql_for_conditions(
+      [
+        # %(EXISTS (SELECT 1 = 1)),
+        %(
+        EXISTS (
+          SELECT 1
+          FROM transitions as transitions
+          WHERE transitions.type = :transition_type
+          AND #{record_class.table_name}.id::varchar = transitions.record_id
+          AND transitions.transitioned_to = :value
+        )
+        ),
+        { transition_type: field_name, record_class:, value: }
+      ]
+    )
+  end
+end
+
+# AND id = transitions.record_id

--- a/app/services/permitted_field_service.rb
+++ b/app/services/permitted_field_service.rb
@@ -45,7 +45,7 @@ class PermittedFieldService
     alert_count assigned_user_names created_at created_by created_by_agency owned_by owned_by_agency_id
     owned_by_text owned_by_agency_office previous_agency previously_owned_by reassigned_tranferred_on reopened_logs
     last_updated_at last_updated_by owned_by_groups previously_owned_by_agency created_organization
-    consent_for_services disclosure_other_orgs case_type
+    consent_for_services disclosure_other_orgs case_type assign
   ].freeze
 
   PERMITTED_DASHBOARD_FILTERS = {

--- a/app/services/search_filter_service.rb
+++ b/app/services/search_filter_service.rb
@@ -44,6 +44,8 @@ class SearchFilterService
       build_or_filter(value)
     elsif key == 'not'
       SearchFilters::Not.new(filter: build_filter(value.keys.first, value.values.first))
+    elsif key == 'assign'
+      build_transition_filter('Assign', value)
     elsif key.starts_with?('loc:')
       build_location_filter(key, value)
     elsif value.is_a?(Hash)
@@ -83,6 +85,10 @@ class SearchFilterService
     return SearchFilters::LocationList.new(field_name:, values: value) if value.is_a?(Array)
 
     SearchFilters::LocationValue.new(field_name:, value:)
+  end
+
+  def build_transition_filter(field_name, value)
+    SearchFilters::TransitionValue.new(field_name:, value:)
   end
 
   def build_id_filter(field_name, value)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -435,6 +435,7 @@ en:
       protection_risks: Protection Risks
       record_state: Record State
       referred_cases: Cases referred to me
+      assigned_to_me: Cases assigned to me
       registration_date: Registration Date
       risk_level: Risk Level
       sex: Sex

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -608,6 +608,7 @@ en:
       date_reunification: Date of Reunification
       tracing_date: Date of Tracing
       service_implemented_day_time: Date Service Completed
+      reassigned_transferred_on: Date Assigned / Transferred On
   configurations:
     apply_label: Are you sure? If you apply, the settings in this configuration will be applied to the system.
       You will lose all your current settings and will not be able to get them back unless you have already saved

--- a/spec/models/filter_spec.rb
+++ b/spec/models/filter_spec.rb
@@ -293,6 +293,7 @@ describe Filter do
           { id: 'reunification_dates', display_name: 'Date of Reunification' },
           { id: 'tracing_dates', display_name: 'Date of Tracing' },
           { id: 'service_implemented_day_times', display_name: 'Date Service Completed' },
+          { id: 'reassigned_transferred_on', display_name: 'Date Assigned / Transferred On' },
           { id: 'created_at', display_name: 'Case Open Date' }
         ]
         expect(


### PR DESCRIPTION
This adds a new filter option for "assigned to me" (it's actually a bit more generic than that on the backend). This was requested as part of the DAO [here](https://unicef.tomars.co/t/assigned-cases-awaiting-for-acceptance-in-home-dashboard/75).

The primary backend change is the addition of a new `TransitionValue` search filter which runs a subquery against the transition table.

New feature in action:

https://github.com/user-attachments/assets/a1e3063f-3e68-42c7-a114-8efd036b6eb0


## Backend Checklist
- [x] RuboCop is passing without warnings on all changed Ruby files
- [x] No new Ruby dependencies have been added to Gemfile
- [x] Solr is not used within any new code
- [ ] Unit tests exist and pass for any new Ruby code
- [ ] Any new Ruby code has been checked for database queries. Excessive or complicated queries will result in performance issues for Primero. Especially be on the lookout for the [N + 1 queries problem](https://guides.rubyonrails.org/active_record_querying.html#n-1-queries-problem).
- [x] There are no outstanding performance issues with the backend code
## Frontend Checklist
- [x] ESLint is passing without any warnings on all changed JavaScript files
- [x] No new JavaScript dependencies have been added to package.json
- [x] Unit tests exist and pass for any new JavaScript code. Unit tests have been written taking [this document](https://github.com/primeroIMS/primero/blob/main/doc/ui_testing.md) into account
~~- [ ] Any application state is handled with Redux~~ N/A
- [x] The [UI/UX guidelines](https://github.com/primeroIMS/primero/blob/main/doc/ui_ux.md) have been taken into account
- [ ] Any new frontend features have been tested on multiple screen sizes, including mobile devices

## Internationalization Checklist
- [x] Any new strings which will be user facing are not literals in the code, but are referenced correctly using the internationalization features
- [x] Translation files for languages other than English have not been updated as these will be overwritten by Transifex
~~- [ ] Any changes in the UI have been tested in both left-to-right and right-to-left languages for things like padding errors~~ N/A
## Non-Technical Checklist
- [x] No vendor-specific dependencies have been added, such as integration with a particular vendor's cloud service or public API
- [x] I understand that this PR may be rejected for any reason, and that having had a proposal approved in the DAO does not guarantee that my code will be merged

