### PR TITLE
Update data_migration README

### DIFF
--- a/db/data_migration/v2.12/README.md
+++ b/db/data_migration/v2.12/README.md
@@ -11,12 +11,12 @@ These scripts will update the roles.
 To validate which roles will be updated, run the following:
 
 ```bash
-rails r ./db/migrations/v2.12/update_roles.rb
+rails r ./db/data_migration/v2.12/update_roles.rb
 ```
 
 ## Executing scripts
 Once you validate that the info is correct you can execute the script to modify the data using:
 
 ```bash
-rails r ./db/migrations/v2.12/update_roles.rb true
+rails r ./db/data_migration/v2.12/update_roles.rb true
 ```

--- a/db/data_migration/v2.13/README.md
+++ b/db/data_migration/v2.13/README.md
@@ -10,7 +10,11 @@ In `v2.13` we are executing a script to store in PosgreSQL the fields that are c
 You can review the data that will updated with:
 
 ```bash
-rails r ./db/data_migration/v2.13/calculate_searchable_values.rb Child file/path.txt
+rails r ./db/data_migration/v2.13/calculate_searchable_values.rb Child false file/path.txt
+```
+
+```bash
+rails r ./db/data_migration/v2.13/calculate_searchable_values.rb Family,Incident,TracingRequest false file/path.txt
 ```
 
 ## Executing scripts
@@ -18,6 +22,10 @@ Once you validate that the info is correct you can execute the script to modify 
 
 ```bash
 rails r ./db/data_migration/v2.13/calculate_searchable_values.rb Child true file/path.txt
+```
+
+```bash
+rails r ./db/data_migration/v2.13/calculate_searchable_values.rb Family,Incident,TracingRequest true file/path.txt
 ```
 
 


### PR DESCRIPTION
Fixing incorrect script path in data_migration README commands (v2.12)
Adding examples for running calculate_searchable_values.rb with different params, including missing 'false' argument (v2.13)