### PR TITLE
Fix subform_section and modules attribute renames breaking db:seed

### DIFF
--- a/db/configuration/forms/case/care_arrangements.rb
+++ b/db/configuration/forms/case/care_arrangements.rb
@@ -98,7 +98,7 @@ care_arrangements_fields = [
   Field.new('name' => 'care_arrangements_section',
             'type' => 'subform',
             'editable' => true,
-            'subform_section' => care_arrangements_section,
+            'subform' => care_arrangements_section,
             'display_name_en' => 'Care Arrangements')
 ]
 

--- a/db/configuration/forms/case/child_wishes.rb
+++ b/db/configuration/forms/case/child_wishes.rb
@@ -43,7 +43,7 @@ child_wishes_fields = [
   Field.new('name' => 'child_preferences_section',
             'type' => 'subform',
             'editable' => true,
-            'subform_section' => child_preferences_section,
+            'subform' => child_preferences_section,
             'display_name_en' => "Child's Preferences")
 ]
 

--- a/db/configuration/forms/case/cp_case_plan.rb
+++ b/db/configuration/forms/case/cp_case_plan.rb
@@ -80,7 +80,7 @@ case_plan_fields = [
   Field.new('name' => 'cp_case_plan_subform_case_plan_interventions',
             'type' => 'subform',
             'editable' => true,
-            'subform_section' => case_plan_section,
+            'subform' => case_plan_section,
             'subform_sort_by' => 'case_plan_timeframe',
             'display_name_en' => 'Intervention plans and services details')
   ## Subform ##

--- a/db/configuration/forms/case/field_notes.rb
+++ b/db/configuration/forms/case/field_notes.rb
@@ -38,7 +38,7 @@ field_notes_subform_section = FormSection.create_or_update!({
 notes_fields = [
   Field.new({ 'name' => 'notes_section',
               'type' => 'subform', 'editable' => true,
-              'subform_section' => field_notes_subform_section,
+              'subform' => field_notes_subform_section,
               'display_name_en' => 'Notes',
               'subform_sort_by' => 'notes_date' })
 ]

--- a/db/configuration/forms/case/followup.rb
+++ b/db/configuration/forms/case/followup.rb
@@ -59,7 +59,7 @@ followup_subform_section = FormSection.create_or_update!(
 followup_fields = [
   Field.new('name' => 'followup_subform_section',
             'type' => 'subform', 'editable' => true,
-            'subform_section' => followup_subform_section,
+            'subform' => followup_subform_section,
             'display_name_en' => 'Follow Up',
             'subform_sort_by' => 'followup_date')
 ]

--- a/db/configuration/forms/case/incident_details.rb
+++ b/db/configuration/forms/case/incident_details.rb
@@ -103,7 +103,7 @@ incident_details_fields = [
   Field.new(
     'name' => 'incident_details',
     'type' => 'subform', 'editable' => true,
-    'subform_section' => incident_details_subform_section,
+    'subform' => incident_details_subform_section,
     'display_name_en' => 'Incident Details',
     'subform_sort_by' => 'summary_date'
   )

--- a/db/configuration/forms/case/protection_concern_details.rb
+++ b/db/configuration/forms/case/protection_concern_details.rb
@@ -45,7 +45,7 @@ protection_concern_detail_fields = [
   Field.new('name' => 'protection_concern_detail_subform_section',
             'type' => 'subform',
             'editable' => true,
-            'subform_section' => protection_concern_detail_subform_section,
+            'subform' => protection_concern_detail_subform_section,
             'display_name_en' => 'Protection Concern Details')
 ]
 

--- a/db/configuration/forms/case/record_owner.rb
+++ b/db/configuration/forms/case/record_owner.rb
@@ -137,7 +137,7 @@ record_owner_fields = [
               'type' => 'subform',
               'editable' => false,
               'disabled' => true,
-              'subform_section' => reopened_logs,
+              'subform' => reopened_logs,
               'display_name_en' => 'Case Reopened',
               'subform_sort_by' => 'reopened_date' })
 ]

--- a/db/configuration/forms/case/referral_transfer.rb
+++ b/db/configuration/forms/case/referral_transfer.rb
@@ -116,7 +116,7 @@ referral_transfer_fields = [
               'type' => 'subform',
               'editable' => false,
               'disabled' => true,
-              'subform_section' => transitions,
+              'subform' => transitions,
               'display_name_en' => 'Transfers and Referrals',
               'subform_sort_by' => 'created_at' })
 ]

--- a/db/configuration/forms/case/services.rb
+++ b/db/configuration/forms/case/services.rb
@@ -119,7 +119,7 @@ services_fields = [
     'name' => 'services_section',
     'type' => 'subform',
     'editable' => true,
-    'subform_section' => services_section,
+    'subform' => services_section,
     'display_name_en' => 'Services',
     'subform_sort_by' => 'service_appointment_date'
   )

--- a/db/configuration/forms/family/family_details.rb
+++ b/db/configuration/forms/family/family_details.rb
@@ -188,7 +188,7 @@ family_members_fields = [
   Field.new(name: 'family_members',
             type: 'subform',
             editable: true,
-            subform_section: family_members_section,
+            subform: family_members_section,
             display_name_en: 'Family Member')
   # #Subform##
 ]

--- a/db/configuration/forms/family/field_notes.rb
+++ b/db/configuration/forms/family/field_notes.rb
@@ -39,7 +39,7 @@ notes_fields = [
   Field.new(name: 'notes_section',
             type: 'subform',
             editable: true,
-            subform_section: field_notes_subform_section,
+            subform: field_notes_subform_section,
             display_name_en: 'Notes',
             subform_sort_by: 'notes_date')
 ]

--- a/db/configuration/forms/tracing_request/tracing_request.rb
+++ b/db/configuration/forms/tracing_request/tracing_request.rb
@@ -94,7 +94,7 @@ tracing_request_tracing_request_fields = [
   Field.new('name' => 'tracing_request_subform_section',
             'type' => 'subform',
             'editable' => true,
-            'subform_section' => tracing_request_subform_section,
+            'subform' => tracing_request_subform_section,
             'display_name_en' => 'Tracing Request')
 ]
 

--- a/db/configuration/users/roles.rb
+++ b/db/configuration/users/roles.rb
@@ -127,7 +127,7 @@ create_or_update_role(
   permissions: cp_admin_permissions,
   group_permission: Permission::ALL,
   is_manager: true,
-  modules: [PrimeroModule.cp]
+  primero_modules: [PrimeroModule.cp]
 )
 
 cp_admin_families_permissions = [
@@ -272,7 +272,7 @@ create_or_update_role(
   permissions: cp_admin_families_permissions,
   group_permission: Permission::ALL,
   is_manager: true,
-  modules: [PrimeroModule.cp]
+  primero_modules: [PrimeroModule.cp]
 )
 
 cp_caseworker_permissions = [
@@ -336,7 +336,7 @@ create_or_update_role(
   unique_id: 'role-cp-case-worker',
   name: 'CP Case Worker',
   permissions: cp_caseworker_permissions,
-  modules: [PrimeroModule.cp]
+  primero_modules: [PrimeroModule.cp]
 )
 
 cp_caseworker_families_permissions = [
@@ -421,7 +421,7 @@ create_or_update_role(
   unique_id: 'role-cp-case-worker-families',
   name: 'CP Case Worker with Families',
   permissions: cp_caseworker_families_permissions,
-  modules: [PrimeroModule.cp]
+  primero_modules: [PrimeroModule.cp]
 )
 
 cp_manager_permissions = [
@@ -510,7 +510,7 @@ create_or_update_role(
   permissions: cp_manager_permissions,
   group_permission: Permission::GROUP,
   is_manager: true,
-  modules: [PrimeroModule.cp]
+  primero_modules: [PrimeroModule.cp]
 )
 
 cp_manager_families_permissions = [
@@ -621,7 +621,7 @@ create_or_update_role(
   permissions: cp_manager_families_permissions,
   group_permission: Permission::GROUP,
   is_manager: true,
-  modules: [PrimeroModule.cp]
+  primero_modules: [PrimeroModule.cp]
 )
 
 cp_user_manager_permissions = [
@@ -694,7 +694,7 @@ create_or_update_role(
   permissions: cp_user_manager_permissions,
   group_permission: Permission::GROUP,
   is_manager: true,
-  modules: [PrimeroModule.cp]
+  primero_modules: [PrimeroModule.cp]
 )
 
 agency_user_admin_permissions = [
@@ -729,7 +729,7 @@ create_or_update_role(
   permissions: agency_user_admin_permissions,
   group_permission: Permission::GROUP,
   is_manager: true,
-  modules: [PrimeroModule.cp]
+  primero_modules: [PrimeroModule.cp]
 )
 
 referral_permissions = [
@@ -762,7 +762,7 @@ create_or_update_role(
   permissions: referral_permissions,
   referral: true,
   form_sections: FormSection.where(unique_id: %w[basic_identity]),
-  modules: [PrimeroModule.cp]
+  primero_modules: [PrimeroModule.cp]
 )
 
 transfer_permissions = [
@@ -794,7 +794,7 @@ create_or_update_role(
   name: 'Transfer',
   permissions: transfer_permissions,
   transfer: true,
-  modules: [PrimeroModule.cp]
+  primero_modules: [PrimeroModule.cp]
 )
 
 cp_serviceprovider_permissions = [
@@ -831,7 +831,7 @@ create_or_update_role(
   referral: true,
   permissions: cp_serviceprovider_permissions,
   form_sections: FormSection.where(unique_id: cp_serviceprovider_forms),
-  modules: [PrimeroModule.cp]
+  primero_modules: [PrimeroModule.cp]
 )
 
 superuser_permissions = [
@@ -923,5 +923,5 @@ create_or_update_role(
   permissions: superuser_permissions,
   group_permission: Permission::ALL,
   is_manager: true,
-  modules: PrimeroModule.all
+  primero_modules: PrimeroModule.all
 )


### PR DESCRIPTION
Field's belongs_to association is :subform (foreign_key: subform_section_id), not :subform_section, but 13 stock form config files still construct Field.new with the old 'subform_section' key. Role's has_and_belongs_to_many association is :primero_modules, not :modules, but roles.rb still uses the old 'modules:' key in all 12 create_or_update_role calls.

Both cause ActiveModel::UnknownAttributeError on a fresh db:seed, so any brand-new deployment of v2.15.1 fails to seed at all.

Fixes #509